### PR TITLE
(#11) Fix remaining valgrind errors

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -511,8 +511,12 @@ Expr_Index move_expr_in_dir(Expr_Buffer *eb, Expr_Index root, Dir dir)
         Expr_Index new_index = expr_buffer_alloc(eb);
 
         expr_buffer_at(eb, new_index)->kind = EXPR_KIND_PLUS;
-        expr_buffer_at(eb, new_index)->as.plus.lhs = move_expr_in_dir(eb, expr_buffer_at(eb, root)->as.plus.lhs, dir);
-        expr_buffer_at(eb, new_index)->as.plus.rhs = move_expr_in_dir(eb, expr_buffer_at(eb, root)->as.plus.rhs, dir);
+
+        Expr_Index tmp = move_expr_in_dir(eb, expr_buffer_at(eb, root)->as.plus.lhs, dir);
+        expr_buffer_at(eb, new_index)->as.plus.lhs = tmp;
+
+        tmp = move_expr_in_dir(eb, expr_buffer_at(eb, root)->as.plus.rhs, dir);
+        expr_buffer_at(eb, new_index)->as.plus.rhs = tmp;
 
         return new_index;
     }


### PR DESCRIPTION
Close #11 

The issue was UB. AFAIK, the computation of the LHS and RHS in an assignment operator is *unsequenced*, so putting `expr_buffer_at` on both sides while calling `move_expr_in_dir` was generating UB. Judging from the valgrind output, gcc probably evaluated the LHS, followed by the argument, then the function, which caused the invalid write since the LHS became invalid. Clang might have done the reverse (RHS then LHS), so no error there.